### PR TITLE
[fix] precompute.py args not used

### DIFF
--- a/precompute.py
+++ b/precompute.py
@@ -9,7 +9,6 @@ if __name__=="__main__":
     if IMAGENET_PATH == "":
         raise ValueError("Please open precompute.py and set IMAGENET_PATH")
     s = (299, 299, 3)
-    dataset = sys.argv[1]
     last_j = 0
     sess = tf.InteractiveSession()
     x = tf.placeholder(tf.float32, s)


### PR DESCRIPTION
Hi,

I followed the documentation:

```
3. Precompute the starting images (for partial-information and label-only attacks) with python precompute.py
```

But it raises an error:

```
Traceback (most recent call last):
  File ".\precompute.py", line 12, in <module>
    dataset = sys.argv[1]
IndexError: list index out of range
```

The varialble `dataset` is not used, thus can be removed safely to avoid the error.